### PR TITLE
gh-actions: Change bzImage to Image in ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           - arch: x86
             image-name: bzImage-x86_64
           - arch: arm64
-            image-name: bzImage-arm64
+            image-name: Image-arm64
     env:
       TAG_VERSION: '${{ github.ref_name }}'
 


### PR DESCRIPTION
This is because the arm64 kernel has no decompression capability, so the resulting file is Image, not the self-extracting archive bzImage