### PR TITLE
[BUG][REJECTED] Fix potential vulnerable cloned function

### DIFF
--- a/drivers/media/tuners/xc2028.c
+++ b/drivers/media/tuners/xc2028.c
@@ -1393,7 +1393,14 @@ static int xc2028_set_config(struct dvb_frontend *fe, void *priv_cfg)
 	/*
 	 * Copy the config data.
 	 */
+	kfree(priv->ctrl.fname);
+	priv->ctrl.fname = NULL;
 	memcpy(&priv->ctrl, p, sizeof(priv->ctrl));
+	if (p->fname) {
+		priv->ctrl.fname = kstrdup(p->fname, GFP_KERNEL);
+		if (priv->ctrl.fname == NULL)
+			return -ENOMEM;
+	}
 
 	/*
 	 * If firmware name changed, frees firmware. As free_firmware will
@@ -1408,14 +1415,9 @@ static int xc2028_set_config(struct dvb_frontend *fe, void *priv_cfg)
 
 	if (priv->state == XC2028_NO_FIRMWARE) {
 		if (!firmware_name[0])
-			priv->fname = kstrdup(p->fname, GFP_KERNEL);
+			priv->fname = priv->ctrl.fname;
 		else
 			priv->fname = firmware_name;
-
-		if (!priv->fname) {
-			rc = -ENOMEM;
-			goto unlock;
-		}
 
 		rc = request_firmware_nowait(THIS_MODULE, 1,
 					     priv->fname,
@@ -1429,7 +1431,6 @@ static int xc2028_set_config(struct dvb_frontend *fe, void *priv_cfg)
 		} else
 			priv->state = XC2028_WAITING_FIRMWARE;
 	}
-unlock:
 	mutex_unlock(&priv->lock);
 
 	return rc;


### PR DESCRIPTION
Hi Development Team,

Our tool identified a potentia vulnerability in a clone function in `drivers/media/tuners/xc2028.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). These issues, originally reported in [CVE-2016-7913](https://nvd.nist.gov/vuln/detail/CVE-2016-7913), were resolved in the repository via this commit https://github.com/torvalds/linux/commit/8dfbcc4351a0b6d2f2d77f367552f48ffefafe18.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!